### PR TITLE
Client-side plugins support added

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,7 @@ Revision 0.2.0, released XX-05-2017
 - Server message classifiers made available at the client side
   for message routing purposes
 - Trunk keep-alive service implemented
+- Client-side plugins support implemented
 - Examples and docs on transparent proxy mode and running at
   secondary interfaces added
 - Performance of the "oidfilter" plugin improved on large

--- a/TODO.txt
+++ b/TODO.txt
@@ -7,6 +7,6 @@
 * unify network endpoint string parser defaulting port part
 * implement GETBULK handling at the "oidfilter" plugin
 * implement PDU split at content map
+* formalize request splitting-merging logic
 * improve logging plugin to expand snmp-* options in log file path
 * cross-link options in configuration docs
-* support plugins at the client part as well

--- a/conf/command-forwarding-logging/client.conf
+++ b/conf/command-forwarding-logging/client.conf
@@ -61,10 +61,20 @@ server-classification-group {
   server-classification-id: any-classification
 }
 
+plugin-modules-path-list: ./plugins ${plugin-dir}
+
+plugin-group {
+  plugin-module: logger
+  plugin-options: config=${config-dir}/plugins/logger.conf
+
+  plugin-id: custom-logger
+}
+
 routing-map {
   matching-trunk-id-list: trunk-1
   matching-orig-snmp-peer-id-list: manager-1
   matching-server-classification-id-list: any-classification
 
+  using-plugin-id-list: custom-logger
   using-snmp-peer-id-list: snmplabs
 }

--- a/conf/command-forwarding-logging/plugins/logger.conf
+++ b/conf/command-forwarding-logging/plugins/logger.conf
@@ -21,7 +21,7 @@ transport: udp
 
 [content]
 #pdus: GetRequest GetNextRequest SetRequest GetBulkRequest InformRequest SNMPv2Trap Response
-pdus: Response
+pdus: GetRequest Response
 
 # log message template
 template: ${isotime} ${snmp-peer-address} ${snmp-pdu-type} ${snmp-var-binds}

--- a/conf/command-forwarding-logging/server.conf
+++ b/conf/command-forwarding-logging/server.conf
@@ -41,15 +41,6 @@ peers-group {
   snmp-peer-id: 100
 }
 
-plugin-modules-path-list: ./plugins ${plugin-dir}
-
-plugin-group {
-  plugin-module: logger
-  plugin-options: config=${config-dir}/plugins/logger.conf
-
-  plugin-id: permit-system-branch
-}
-
 trunking-group {
   trunk-bind-address: 127.0.0.1
   trunk-peer-address: 127.0.0.1:30301
@@ -66,6 +57,5 @@ routing-map {
   matching-snmp-credentials-id-list: snmp-credentials
   matching-snmp-peer-id-list: 100
 
-  using-plugin-id-list: permit-system-branch
   using-trunk-id-list: trunk-1
 }

--- a/docs/source/configuration/client-configuration.rst
+++ b/docs/source/configuration/client-configuration.rst
@@ -294,6 +294,66 @@ Example:
       snmp-peer-id: 101
     }
 
+.. _plugin-options-client:
+
+Plugin options
+--------------
+
+The plugin options instantiate a :ref:`plugin <plugins>` file with
+specific configuration options and assign an identifier to it. You
+can have many differently configured instances of the same plugin
+module in the system.
+
+.. note::
+
+    Server-side plugins are also :ref:`available <plugin-options-server>`.
+
+*plugin-modules-path-list*
+++++++++++++++++++++++++++
+
+Directory search path for plugin modules.
+
+This option can reference :ref:`config-dir <config-dir-macro>` macro.
+
+*plugin-module*
++++++++++++++++
+
+Plugin module file name to load and run (without .py).
+
+*plugin-options*
+++++++++++++++++
+
+Plugin-specific configuration option to pass to plugin.
+
+*plugin-id*
++++++++++++
+
+Unique identifier of a plugin module (`plugin-module`_) and its
+options (`plugin-options`_).
+
+This option can reference :ref:`config-dir <config-dir-macro>` macro.
+
+The *plugin-id* identifier is typically used to invoke plugin
+in the course of SNMP message processing.
+
+Example:
+
+.. code-block:: bash
+
+    rewrite-plugin {
+      plugin-module: rewrite
+      plugin-options: config=${config-dir}/plugins/rewrite.conf
+
+      plugin-id: rewrite
+    }
+
+    logging-plugin {
+      plugin-module: logger
+      plugin-options: config=/etc/snmpfwd/plugins/logger.conf
+
+      plugin-id: logger
+    }
+
 Trunking options
 ----------------
 
@@ -566,6 +626,15 @@ any of `orig-snmp-peer-id`_'s in the list.
 Evaluates to True if server SNMP request message classifiers match
 any of `server-classification-id`_'s in the list.
 
+*using-plugin-id-list*
+++++++++++++++++++++++
+
+Invoke each of the `plugin-id`_ in the list in order passing request and response
+SNMP PDUs from one :ref:`plugin <plugins>` to the other.
+
+Plugins may modify the message in any way and even block it from further
+propagation in which case SNMP message will be dropped.
+
 *using-snmp-peer-id-list*
 +++++++++++++++++++++++++
 
@@ -573,7 +642,7 @@ Unique identifier matching a group of *matching-\** identifiers. Specifically,
 these are: `matching-trunk-id-list`_, `matching-orig-snmp-peer-id-list`_ and
 `matching-server-classification-id-list`_.
 
-SNMP request message will be passed to to each `snmp-peer-id`_'a present
+SNMP request message will be sent to each `snmp-peer-id`_ present
 in the list.
 
 Example:
@@ -586,6 +655,7 @@ Example:
         matching-orig-snmp-peer-id-list: manager-123
         matching-server-classification-id-list: any-classification
 
+        using-plugin-id-list: oidfilter
         using-snmp-peer-id-list: backend-agent-A
       }
     }

--- a/docs/source/configuration/examples/command-forwarding-logging.rst
+++ b/docs/source/configuration/examples/command-forwarding-logging.rst
@@ -20,25 +20,24 @@ Server is configured to:
 * respond to queries performed over SNMPv2c
 * forward all queries to snmpfwd client through an unencrypted trunk connection
   running in *client* mode
-* run command request PDUs through the *logger* plugin
 
-.. literalinclude:: /../../conf/command-forwarding-rewriting-response/server.conf
+.. literalinclude:: /../../conf/command-forwarding-logging/server.conf
 
-:download:`Download </../../conf/command-forwarding-with-logging/server.conf>` server configuration file.
+:download:`Download </../../conf/command-forwarding-logging/server.conf>` server configuration file.
 
 Plugin configuration
 ++++++++++++++++++++
 
-The *logger* plugin is configured to:
+The *logger* plugin is configured at the client side to:
 
-* write key facts about passing SNMP response PDU into a local file
+* write key facts about passing SNMP GET request and RESPONSE PDUs into a local file
 * double-quote var-bindings values
 * autorotate log file daily
 * keep no more than 30 log files
 
-.. literalinclude:: /../../conf/command-forwarding-with-logging/plugins/logger.conf
+.. literalinclude:: /../../conf/command-forwarding-logging/plugins/logger.conf
 
-:download:`Download </../../conf/command-forwarding-with-logging/plugins/logger.conf>` plugin configuration file.
+:download:`Download </../../conf/command-forwarding-logging/plugins/logger.conf>` plugin configuration file.
 
 Client configuration
 --------------------
@@ -47,9 +46,10 @@ Client is configured to:
 
 * listen on server-mode unencrypted trunk connection
 * process all incoming SNMP messages in the same way
+* run command request (and response) PDUs through the *logger* plugin
 * place inbound PDUs into SNMP v2c messages and forward them to public
   SNMP agent running at *demo.snmplabs.com*
 
-.. literalinclude:: /../../conf/command-forwarding-with-logging/client.conf
+.. literalinclude:: /../../conf/command-forwarding-logging/client.conf
 
-:download:`Download </../../conf/command-forwarding-with-logging/client.conf>` client configuration file.
+:download:`Download </../../conf/command-forwarding-logging/client.conf>` client configuration file.

--- a/docs/source/configuration/examples/command-forwarding-oid-filtering.rst
+++ b/docs/source/configuration/examples/command-forwarding-oid-filtering.rst
@@ -46,8 +46,9 @@ Server is configured to:
 Plugin configuration
 ++++++++++++++++++++
 
-The *oidfilter* plugin is configured to pass just a few specific OIDs and branches
-blocking the rest of the MIB tree that backend SNMP agent serve.
+The *oidfilter* plugin is configured at the server side to pass just a
+few specific OIDs and branches blocking the rest of the MIB tree that
+backend SNMP agent serve.
 
 .. literalinclude:: /../../conf/command-forwarding-filtering/plugins/oidfilter.conf
 

--- a/docs/source/configuration/examples/command-forwarding-rewriting-response.rst
+++ b/docs/source/configuration/examples/command-forwarding-rewriting-response.rst
@@ -43,8 +43,8 @@ Server is configured to:
 Plugin configuration
 ++++++++++++++++++++
 
-The *rewrite* plugin is configured to add a note into sysDescr.0 and nullify all values
-in the "system" branch.
+The *rewrite* plugin is configured at the server part to add a note into
+sysDescr.0 and nullify all values in the "system" branch.
 
 .. literalinclude:: /../../conf/command-forwarding-rewriting-response/plugins/rewrite.conf
 

--- a/docs/source/configuration/index.rst
+++ b/docs/source/configuration/index.rst
@@ -80,8 +80,25 @@ global scope.
    client-configuration
    macro
 
+.. _plugins:
+
 Plugins
 -------
+
+Both :ref:`client <plugin-options-client>` and
+:ref:`server <plugin-options-server>` parts of SNMP Proxy Forwarder
+can be configured to pass PDUs through a chain of plugin modules.
+A plugin module can modify or replace passing PDU or take any other
+action of its choice.
+
+Each plugin module is a Python code snippet executing within the
+context of a single SNMP query and exposing a few entry points for
+the server or client parts of SNMP Proxy Forwarder to invoke it at
+the key points of SNMP PDU processing.
+
+You can run the same or different plugin modules at both client
+and server. The choice of plugin runner probably depends on the
+system architecture, load distribution and security considerations.
 
 .. toctree::
    :maxdepth: 2

--- a/docs/source/configuration/server-configuration.rst
+++ b/docs/source/configuration/server-configuration.rst
@@ -289,8 +289,19 @@ Example:
       snmp-credentials-id: snmpv3-agent-at-localhost
     }
 
+.. _plugin-options-server:
+
 Plugin options
 --------------
+
+The plugin options instantiate a :ref:`plugin <plugins>` file with
+specific configuration options and assign an identifier to it. You
+can have many differently configured instances of the same plugin
+module in the system.
+
+.. note::
+
+    Client-side plugins are also :ref:`available <plugin-options-client>`.
 
 *plugin-modules-path-list*
 ++++++++++++++++++++++++++
@@ -593,8 +604,8 @@ one of the `snmp-peer-id`_ in the list.
 *using-plugin-id-list*
 ++++++++++++++++++++++
 
-Invoke each of the `plugin-id`_ in the list in order and and pass incoming
-SNMP message from one to the other.
+Invoke each of the `plugin-id`_ in the list in order passing request and response
+SNMP PDUs from one :ref:`plugin <plugins>` to the other.
 
 Plugins may modify the message in any way and even block it from further
 propagation in which case SNMP message will be dropped.
@@ -606,7 +617,7 @@ Unique identifier matching a group of *matching-\** identifiers. Specifically,
 these are: `matching-snmp-context-id-list`_, `matching-snmp-content-id-list`_,
 `matching-snmp-credentials-id-list`_ and `matching-snmp-peer-id-list`_.
 
-Incoming (and possibly modified) SNMP message will be passed to to each
+Incoming (and possibly modified) SNMP message will be forwarded to each
 `trunk-id`_ present in the list.
 
 Example:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -2,12 +2,32 @@
 SNMP Proxy Forwarder
 ====================
 
-The SNMP Proxy forwarder tool works as an application-level SNMP proxy
-logically split onto two parts: server and client. The server part
+The SNMP Proxy Forwarder tool is a standards-compliant, flexible,
+multiprotocol SNMP proxy implementation.
+
+Key features:
+
+* Complete SNMPv1/v2c/v3 support with built-in protocol and transport
+  translation capabilities
+* Forwards SNMP commands and notifications
+* Maintains multiple independent SNMP engines and network transports
+* Split client and server parts
+* Configurable SNMP PDU routing policy
+* Extension modules supporting SNMP PDU filtering and on-the-fly modification
+* Supports transparent proxy operation (Linux only)
+* Works on Linux, Windows and OS X
+
+Architecture
+------------
+
+The otherwise monolithic SNMP proxy is split onto two parts: server and client.
+For SNMP commands, server part
 acts as `SNMP agent <https://tools.ietf.org/html/rfc3411#section-3.1.3.2>`_
 while the client part is `SNMP manager <https://tools.ietf.org/html/rfc3411#section-3.1.3.1>`_.
-These parts maintain persistent, authenticated and encrypted connections with
-each other for the purpose of passing SNMP messages back and forth.
+For SNMP notifications server and client roles are reversed.
+The server and client parts maintain persistent, authenticated and encrypted
+connections with each other for the purpose of passing SNMP messages back
+and forth.
 
 Server and client parts may reside at different networks thus improving
 security and network isolation.
@@ -25,12 +45,12 @@ chose SNMP agent to forward SNMP message to depending on the original
 destination address at which server part received SNMP message in the
 first place.
 
-Besides SNMP message routing, server part can modify SNMP messages
-before passing them on to clients. Changes may apply to both incoming
-and outgoing SNMP messages. The logic powering SNMP message modification
+Besides SNMP message routing, both server and client parts can modify
+SNMP PDU messages before passing them on. Changes may apply to both incoming
+and outgoing SNMP PDU messages. The logic powering SNMP message modification
 can be expressed in form of isolated `Python <http://www.python.org>`_
-snippets called *plugins*. Users can implement their own plugins and let
-server part of SNMP proxy forwarder calling them.
+snippets called :ref:`plugins <plugins>`. Users can implement their own
+plugins and let SNMP Proxy Forwarder calling them.
 
 Configuration
 -------------

--- a/plugins/logger.py
+++ b/plugins/logger.py
@@ -92,7 +92,7 @@ def _format(template, pdu, context):
     for key, value in context.items():
         token = '${%s}' % key
         if token in template:
-            template = template.replace(token, value)
+            template = template.replace(token, str(value))
 
     token = '${snmp-var-binds}'
     if token in template:

--- a/scripts/snmpfwd-client.py
+++ b/scripts/snmpfwd-client.py
@@ -461,7 +461,7 @@ def main():
 
         srvClassIdList.append((srvClassId, re.compile(k)))
 
-    duplicates = {}
+    del duplicates
 
     for pluginCfgPath in cfgTree.getPathsToAttr('using-plugin-id-list'):
         pluginIdList = cfgTree.getAttrValue('using-plugin-id-list', *pluginCfgPath, **dict(vector=True))
@@ -482,8 +482,6 @@ def main():
                                 sys.exit(-1)
 
                         pluginIdMap[k] = pluginIdList
-
-    del duplicates
 
     for routeCfgPath in cfgTree.getPathsToAttr('using-snmp-peer-id-list'):
         peerIdList = cfgTree.getAttrValue('using-snmp-peer-id-list', *routeCfgPath, **dict(vector=True))

--- a/scripts/snmpfwd-client.py
+++ b/scripts/snmpfwd-client.py
@@ -5,6 +5,7 @@
 # Copyright (c) 2014-2017, Ilya Etingof <etingof@gmail.com>
 # License: https://github.com/etingof/snmpfwd/blob/master/LICENSE.txt
 #
+import os
 import sys
 import getopt
 import traceback
@@ -32,12 +33,15 @@ from pysnmp import debug as pysnmp_debug
 from snmpfwd import macro
 from snmpfwd.error import SnmpfwdError
 from snmpfwd import log, daemon, cparser
+from snmpfwd.plugins.manager import PluginManager
+from snmpfwd.plugins import status
 from snmpfwd.trunking.manager import TrunkingManager
 
 # Settings
 PROGRAM_NAME = 'snmpfwd-client'
 CONFIG_FILE = '/usr/local/etc/snmpfwd/client.cfg'
 CONFIG_VERSION = '2'
+PLUGIN_API_VERSION = 2
 
 authProtocols = {
   'MD5': config.usmHMACMD5AuthProtocol,
@@ -181,12 +185,38 @@ def main():
     origCredIdList = []
     srvClassIdList = []
     peerIdMap = {}
+    pluginIdMap = {}
     routingMap = {}
     engineIdMap = {}
 
     transportDispatcher = AsynsockDispatcher()
     transportDispatcher.registerRoutingCbFun(lambda td, t, d: td)
     transportDispatcher.setSocketMap()  # use global asyncore socket map
+
+    pluginManager = PluginManager(
+        macro.expandMacros(
+            cfgTree.getAttrValue('plugin-modules-path-list', '', default=[], vector=True),
+            {'config-dir': os.path.dirname(cfgFile)}
+        ),
+        progId=PROGRAM_NAME,
+        apiVer=PLUGIN_API_VERSION
+    )
+
+    for pluginCfgPath in cfgTree.getPathsToAttr('plugin-id'):
+        pluginId = cfgTree.getAttrValue('plugin-id', *pluginCfgPath)
+        pluginMod = cfgTree.getAttrValue('plugin-module', *pluginCfgPath)
+        pluginOptions = macro.expandMacro(
+            cfgTree.getAttrValue('plugin-options', *pluginCfgPath, **dict(default='')),
+            {'config-dir': os.path.dirname(cfgFile)}
+        )
+
+        log.msg('configuring plugin ID %s (at %s) from module %s with options %s...' % (pluginId, '.'.join(pluginCfgPath), pluginMod, pluginOptions or '<none>'))
+        try:
+            pluginManager.loadPlugin(pluginId, pluginMod, pluginOptions)
+
+        except SnmpfwdError:
+            log.msg('ERROR: plugin %s not loaded: %s' % (pluginId, sys.exc_info()[1]))
+            sys.exit(-1)
 
     for peerEntryPath in cfgTree.getPathsToAttr('snmp-peer-id'):
         peerId = cfgTree.getAttrValue('snmp-peer-id', *peerEntryPath)
@@ -431,6 +461,28 @@ def main():
 
         srvClassIdList.append((srvClassId, re.compile(k)))
 
+    duplicates = {}
+
+    for pluginCfgPath in cfgTree.getPathsToAttr('using-plugin-id-list'):
+        pluginIdList = cfgTree.getAttrValue('using-plugin-id-list', *pluginCfgPath, **dict(vector=True))
+        log.msg('configuring plugin ID(s) %s (at %s)...' % (','.join(pluginIdList), '.'.join(pluginCfgPath)))
+        for credId in cfgTree.getAttrValue('matching-orig-snmp-peer-id-list', *pluginCfgPath, **dict(vector=True)):
+            for srvClassId in cfgTree.getAttrValue('matching-server-classification-id-list', *pluginCfgPath, **dict(vector=True)):
+                for trunkId in cfgTree.getAttrValue('matching-trunk-id-list', *pluginCfgPath, **dict(vector=True)):
+                    k = credId, srvClassId, trunkId
+                    if k in pluginIdMap:
+                        log.msg('duplicate snmp-credentials-id=%s and server-classification-id=%s and trunk-id=%s at plugin-id %s' % (credId, srvClassId, trunkId, ','.join(pluginIdList)))
+                        sys.exit(-1)
+                    else:
+                        log.msg('configuring plugin(s) %s (at %s), composite key: %s' % (','.join(pluginIdList), '.'.join(pluginCfgPath), '/'.join(k)))
+
+                        for pluginId in pluginIdList:
+                            if not pluginManager.hasPlugin(pluginId):
+                                log.msg('ERROR: undefined plugin ID %s referenced at %s' % (pluginId, '.'.join(pluginCfgPath)))
+                                sys.exit(-1)
+
+                        pluginIdMap[k] = pluginIdList
+
     del duplicates
 
     for routeCfgPath in cfgTree.getPathsToAttr('using-snmp-peer-id-list'):
@@ -441,7 +493,7 @@ def main():
                 for trunkId in cfgTree.getAttrValue('matching-trunk-id-list', *routeCfgPath, **dict(vector=True)):
                     k = credId, srvClassId, trunkId
                     if k in routingMap:
-                        log.msg('duplicate credentials-id=%s and trunk-id and server-classification-id %s at peer-id %s' % (credId, trunkId, ','.join(peerIdList)))
+                        log.msg('duplicate snmp-credentials-id=%s and server-classification-id=%s and trunk-id=%s at snmp-peer-id %s' % (credId, srvClassId, trunkId, ','.join(peerIdList)))
                         sys.exit(-1)
                     else:
                         for peerId in peerIdList:
@@ -455,13 +507,39 @@ def main():
         return not pdu and '<none>' or ';'.join(['%s:%s' % (vb[0].prettyPrint(), vb[1].prettyPrint()) for vb in v2c.apiPDU.getVarBinds(pdu)])
 
     def __rspCbFun(snmpEngine, sendRequestHandle, errorIndication, rspPDU, cbCtx):
-        trunkId, msgId, trunkReq = cbCtx
+        trunkId, msgId, trunkReq, pluginIdList, snmpReqInfo, reqCtx = cbCtx
 
         trunkRsp = {}
 
         if errorIndication:
             log.msg('SNMP error returned for message ID %s received from trunk %s: %s' % (msgId, trunkId, errorIndication))
             trunkRsp['error-indication'] = errorIndication
+
+        reqPdu = trunkReq['snmp-pdu']
+
+        if rspPDU:
+            for pluginId in pluginIdList:
+                if reqPdu.tagSet in rfc3411.notificationClassPDUs:
+                    st, rspPDU = pluginManager.processNotificationResponse(
+                        pluginId, snmpEngine, rspPDU, snmpReqInfo, reqCtx
+                    )
+
+                elif reqPdu.tagSet not in rfc3411.unconfirmedClassPDUs:
+                    st, rspPDU = pluginManager.processCommandResponse(
+                        pluginId, snmpEngine, rspPDU, snmpReqInfo, reqCtx
+                    )
+                else:
+                    log.msg('ignoring unsupported PDU')
+                    break
+
+                if st == status.BREAK:
+                    break
+
+                elif st == status.DROP:
+                    log.msg('received SNMP %s message, snmp-var-binds=%s, plugin %s muted response' % (errorIndication and 'error' or 'response', prettyVarBinds(rspPDU), pluginId))
+                    trunkRsp['snmp-pdu'] = None
+                    trunkingManager.sendRsp(trunkId, msgId, trunkRsp)
+                    return
 
         trunkRsp['snmp-pdu'] = rspPDU
 
@@ -523,23 +601,31 @@ def main():
 
         errorIndication = None
 
+        pluginIdList = pluginIdMap.get((origPeerId, srvClassId, macro.expandMacro(trunkId, msg)))
+
         peerIdList = routingMap.get((origPeerId, srvClassId, macro.expandMacro(trunkId, msg)))
         if not peerIdList:
             log.msg('unroutable trunk message #%s from trunk %s, srv-classification-id %s, orig-peer-id %s (original SNMP info: %s)' % (msgId, trunkId, srvClassId, origPeerId or '<none>', ', '.join([x == 'snmp-pdu' and 'snmp-var-binds=%s' % prettyVarBinds(msg['snmp-pdu']) or '%s=%s' % (x, msg[x].prettyPrint()) for x in msg])))
             errorIndication = 'no route to SNMP peer configured'
 
-        cbCtx = trunkId, msgId, msg
+        cbCtx = trunkId, msgId, msg, (), {}, {}
 
         if errorIndication:
             __rspCbFun(None, None, errorIndication, None, cbCtx)
             return
 
+        log.msg('received trunk message #%s from trunk %s' % (msgId, trunkId))
+
         for peerId in peerIdList:
             peerId = macro.expandMacro(peerId, msg)
 
-            snmpEngine, contextEngineId, contextName, \
-                bindAddr, bindAddrMacro, \
-                peerAddr, peerAddrMacro = peerIdMap[peerId]
+            (snmpEngine,
+             contextEngineId,
+             contextName,
+             bindAddr,
+             bindAddrMacro,
+             peerAddr,
+             peerAddrMacro) = peerIdMap[peerId]
 
             if bindAddrMacro:
                 bindAddr = macro.expandMacro(bindAddrMacro, msg), 0
@@ -551,9 +637,47 @@ def main():
             if peerAddr:
                 q.append(peerAddr)
 
-            log.msg('received trunk message #%s from trunk %s, sending SNMP message to peer ID %s, bind-address %s, peer-address %s (original SNMP info: %s; original server classification: %s)' % (msgId, trunkId, peerId, bindAddr[0] or '<default>', peerAddr[0] or '<default>', ', '.join([x == 'snmp-pdu' and 'snmp-var-binds=%s' % prettyVarBinds(msg['snmp-pdu']) or '%s=%s' % (x, msg[x].prettyPrint()) for x in msg if x.startswith('snmp-')]), ' '.join(['%s=%s' % (x, msg[x].prettyPrint()) for x in msg if x.startswith('server-')])))
+            logMsg = 'SNMP message to peer ID %s, bind-address %s, peer-address %s (original SNMP info: %s; original server classification: %s)' % (peerId, bindAddr[0] or '<default>', peerAddr[0] or '<default>', ', '.join([x == 'snmp-pdu' and 'snmp-var-binds=%s' % prettyVarBinds(msg['snmp-pdu']) or '%s=%s' % (x, msg[x].prettyPrint()) for x in msg if x.startswith('snmp-')]), ' '.join(['%s=%s' % (x, msg[x].prettyPrint()) for x in msg if x.startswith('server-')]))
+
+            log.msg('sending %s' % logMsg)
 
             pdu = msg['snmp-pdu']
+
+            if pluginIdList:
+                snmpReqInfo = msg.copy()
+                reqCtx = {}
+
+                cbCtx = trunkId, msgId, msg, pluginIdList, snmpReqInfo, reqCtx
+
+                for pluginNum, pluginId in enumerate(pluginIdList):
+
+                    if pdu.tagSet in rfc3411.notificationClassPDUs:
+                        st, pdu = pluginManager.processNotificationRequest(
+                            pluginId, snmpEngine, pdu, snmpReqInfo, reqCtx
+                        )
+
+                    elif pdu.tagSet not in rfc3411.unconfirmedClassPDUs:
+                        st, pdu = pluginManager.processCommandRequest(
+                            pluginId, snmpEngine, pdu, snmpReqInfo, reqCtx
+                        )
+
+                    else:
+                        log.msg('ignoring unsupported PDU')
+                        break
+
+                    if st == status.BREAK:
+                        cbCtx = trunkId, msgId, msg, pluginIdList[:pluginNum], snmpReqInfo, reqCtx
+                        break
+
+                    elif st == status.DROP:
+                        log.msg('plugin %s muted request %s' % (pluginId, logMsg))
+                        __rspCbFun(snmpEngine, None, None, None, cbCtx)
+                        break
+
+                    elif st == status.RESPOND:
+                        log.msg('plugin %s forced immediate response to %s' % (pluginId, logMsg))
+                        __rspCbFun(snmpEngine, None, None, pdu, cbCtx)
+                        break
 
             if pdu.tagSet in rfc3411.notificationClassPDUs:
                 if pdu.tagSet in rfc3411.unconfirmedClassPDUs:


### PR DESCRIPTION
This PR extends plugins subsystem to the client part. Now users can configure snmpfwd to invoke plugins at server and/or client parts depending on the network topology, load distribution etc.